### PR TITLE
[FIX #15] Output from running notebook is now hidden.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Usage to execute utility notebooks:
 
 ```python
 from livingpark_utils.scripts import run
+
 run.mri_metadata()
 run.pd_status()
 ```

--- a/README.md
+++ b/README.md
@@ -18,10 +18,9 @@ utils.moca2mmse(2)
 Usage to execute utility notebooks:
 
 ```python
-from livingpark_utils.scripts import (
-    mri_metadata,
-    pd_status,
-)
+from livingpark_utils.scripts import run
+run.mri_metadata()
+run.pd_status()
 ```
 
 Note: This will execute the notebooks directly.

--- a/livingpark_utils/scripts/_gen_run.py
+++ b/livingpark_utils/scripts/_gen_run.py
@@ -20,6 +20,7 @@ Notes
 The methods below need to be created manually when a new notebook is added.
 \"\"\"
 import importlib
+from IPython.utils import io
 """
     )
 
@@ -38,7 +39,8 @@ for root, dirs, files in os.walk(notebooks_dir):
 
 def $func_name():
     \"\"\"Execute auto-generated script for `../notebooks/${func_name}.ipynb`.\"\"\"
-    importlib.import_module(\"$func_name\", \"livingpatk_utils.scripts\")
+    with io.capture_output():
+        importlib.import_module(\"$func_name\", \"livingpark_utils.scripts\")
 """
                 )
                 fout.write(


### PR DESCRIPTION
This PR hides the output when calling auto-generated notebook scripts.
It captures the IPython io and never display it.

This also make proper use of the `livingpark_utils.scripts.run` module which requires to call function to execute the script. Previously, the scripts where called directly by importing their respective files.
Changing to this method will give more flexibility in the long term to wrap the script. For example, potentially passing arguments when calling the notebook scripts.