### PR TITLE
[ADD] cli to download T1 nifti files outside.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,15 @@ run.pd_status()
 
 Note: Optionally use the `%%capture` cell magic to further hide notebook outputs.
 
+# CLI commands
+
+Download T1 nifti files using a cohort definition file.
+
+```
+$ get_T1_nifti_files <cohort_file> --downloader (ppmi) [--symlink=<bool>]
+[--force=<bool>] [--timeout=<int>]
+```
+
 ## Troubleshooting
 
 ### Permission issues on Windows

--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ $ get_T1_nifti_files <cohort_file> --downloader (ppmi) [--symlink=<bool>]
 [--force=<bool>] [--timeout=<int>]
 ```
 
+The `cohort_file` is a csv file created beforehand. Respectively to the chosen downloader, it must have the following columns:
+* PPMI: `PATNO`, `EVENT_ID`, and `Description`.
+
 ## Troubleshooting
 
 ### Permission issues on Windows

--- a/livingpark_utils/cli.py
+++ b/livingpark_utils/cli.py
@@ -56,9 +56,10 @@ def get_T1_nifti_files(
     timeout: int,
     cohort_file: str,
 ):
-    """Download T1 nifti files from cohort csv file.
+    r"""Download T1 nifti files from cohort csv file.
 
     The csv file is generated in he Jupyter notebook for cohort definition.
+    \f
 
     Parameters
     ----------

--- a/livingpark_utils/cli.py
+++ b/livingpark_utils/cli.py
@@ -1,0 +1,88 @@
+"""CLI entrypoint for livingpark utilities."""
+from typing import Any
+
+import click
+import pandas as pd
+
+import livingpark_utils
+
+
+def import_from(module: str, name: str) -> Any:
+    """Import an object from a given module.
+
+    Parameters
+    ----------
+    module : str
+        Import path to the module containing the object.
+    name : str
+        Object to import withing the module.
+
+    Returns
+    -------
+    Any
+        Object to import.
+    """
+    module_obj = __import__(module, fromlist=[name])
+    return getattr(module_obj, name)
+
+
+@click.command()
+@click.option("--downloader", type=click.Choice(["ppmi"]))
+@click.option(
+    "--symlink",
+    type=bool,
+    default=True,
+    help="Create symlink between the cache and the `input`/`output` directories.",
+)
+@click.option(
+    "--force",
+    type=bool,
+    default=False,
+    help="Download all the subject files regardless of local cache.",
+)
+@click.option(
+    "--timeout",
+    type=int,
+    default=120,
+    help="Maximum duration before interrupting the download (per subject).",
+)
+@click.argument(
+    "cohort_file", type=click.Path(exists=True, file_okay=True, readable=True)
+)
+def get_T1_nifti_files(
+    downloader: str,
+    symlink: bool,
+    force: bool,
+    timeout: int,
+    cohort_file: str,
+):
+    """Download T1 nifti files from cohort csv file.
+
+    The csv file is generated in he Jupyter notebook for cohort definition.
+
+    Parameters
+    ----------
+    downloader : str
+        Type of downloader to use. Choices: ["ppmi"].
+    symlink : bool
+        When `True`, symlinks are created from the caching directory., by default
+            True.
+    force : bool
+        When `True`, all study files are reported missing locally., by default False.
+    timeout : int
+        Number of second before the download times out., by default 120.
+    cohort_file : str
+        Path to the csv file containing the cohort definition.
+    """
+    utils = livingpark_utils.LivingParkUtils()
+    download_handler = import_from(
+        f"livingpark_utils.download.{downloader}", "Downloader"
+    )(utils.study_files_dir)
+
+    utils.get_T1_nifti_files(
+        pd.read_csv(cohort_file),
+        default=download_handler,
+        symlink=symlink,
+        force=force,
+        timeout=timeout,
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,12 @@ dependencies = [
     "numpy",
     "pandas",
     "pytz",
+    "click",
 ]
+
+[project.scripts]
+get_T1_nifti_files = "livingpark_utils.cli:get_T1_nifti_files"
+
 
 [project.urls]
 "Bug Tracker" = "https://github.com/LivingPark-MRI/livingpark_utils/issues"


### PR DESCRIPTION
This will let us download T1 nifti files on cluster (e.g. Compute Canada) without having to spawn a Jupyter notebook.
Therefore, it requires fewer resources from the login node and speeds up the download.