### PR TITLE
Update requirements for ppmi-downloader

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "livingpark_utils"
-version = "0.6"
+version = "0.8"
 description = "Utility functions to write LivingPark notebooks."
 authors = [{ name = "Tristan Glatard", email = "tristan.glatard@concordia.ca" }]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ license = { file = "LICENSE" }
 dependencies = [
     "datalad",
     "IPython",
-    "ppmi_downloader",
+    "ppmi_downloader>=0.7",
     "nilearn",
     "boutiques",
     "pillow",


### PR DESCRIPTION
- Versions of `ppmi-downloader` < 0.7 have old PPMI API.