### PR TITLE
Fix download of T1 images.

### DIFF
--- a/livingpark_utils/download/ppmi.py
+++ b/livingpark_utils/download/ppmi.py
@@ -124,13 +124,12 @@ class Downloader(DownloaderABC):
         cohort = query
         missing_patno = cohort["PATNO"]
         try:
-            ppmi_dl = ppmi_downloader.PPMIDownloader()
+            ppmi_dl = ppmi_downloader.PPMIDownloader(headless=self.headless)
             print(f"Downloading image data of {missing_patno.nunique()} subjects")
             ppmi_dl.download_imaging_data(
                 missing_patno.unique(),
                 type="nifti",
                 timeout=timeout * missing_patno.nunique(),
-                headless=self.headless,
             )
         except Exception:
             missing = self.missing_T1_nifti_files(query)

--- a/livingpark_utils/download/ppmi.py
+++ b/livingpark_utils/download/ppmi.py
@@ -1,5 +1,6 @@
 """Downloader for the ppmi dataset."""
 import os.path
+import traceback
 
 import pandas as pd
 import ppmi_downloader
@@ -61,8 +62,8 @@ class Downloader(DownloaderABC):
                 destination_dir=self.out_dir,
                 timeout=timeout,
             )
-        except Exception as e:
-            print(e)
+        except Exception:
+            print(traceback.format_exc())
             missing = self.missing_study_files(query)
             success = list(set(query) - set(missing))
             return success, missing
@@ -132,6 +133,7 @@ class Downloader(DownloaderABC):
                 timeout=timeout * missing_patno.nunique(),
             )
         except Exception:
+            print(traceback.format_exc())
             missing = self.missing_T1_nifti_files(query)
             success = query[~query["PATNO"].isin(missing["PATNO"])]
             return success, missing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "livingpark_utils"
-version = "0.9"
+version = "0.9.1"
 description = "Utility functions to write LivingPark notebooks."
 authors = [{ name = "Tristan Glatard", email = "tristan.glatard@concordia.ca" }]
 readme = "README.md"


### PR DESCRIPTION
The `download.ppmi.Downloader` broke after [a change](54e61070c5fa68f6968e0cf7bd8c84b2b3a2187e) to the `ppmi_downloader` api.

This PR fix this issue.Also, it adds output traceback when an exception occurs and bump the version for release.