### PR TITLE
Updates following PPMI data schema update

### DIFF
--- a/livingpark_utils/notebooks/pd_status.ipynb
+++ b/livingpark_utils/notebooks/pd_status.ipynb
@@ -22,8 +22,8 @@
     "The medication status of PD patients is important as medication importantly affects clinical measures such as the Hoehn & Yahr score used in many studies. In PPMI, medication is available through the following main variables:\n",
     "* PDSTATE (ON/OFF): the current functional state of the patient\n",
     "* PDTRTMNT (0/1): 1 if the participant is on PD medication or receives deep brain stimulation, 0 otherwise\n",
-    "* PDMEDTM: time of most recent PD medication dose\n",
-    "* PDMEDDT: date of most recent PD medication dose\n",
+    "* ON/OFFPDMEDTM: time of most recent PD medication dose\n",
+    "* ON/OFFPDMEDDT: date of most recent PD medication dose\n",
     "\n",
     "As mentioned in the \"Methods for Defining PD Med Use\" in PPMI study data, OFF state requires that the last dose of levodopa or dopamine agonist was taken 6 hours or more before MDS-UPDRS Part III assessment.\n",
     "\n",
@@ -32,9 +32,35 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<script>\n",
+       "code_show=true; \n",
+       "function code_toggle() {\n",
+       " if (code_show){\n",
+       " $('div.input').hide();\n",
+       " } else {\n",
+       " $('div.input').show();\n",
+       " }\n",
+       " code_show = !code_show\n",
+       "} \n",
+       "$( document ).ready(code_toggle);\n",
+       "</script>\n",
+       "<form action=\"javascript:code_toggle()\"><input type=\"submit\" value=\"Click here to toggle on/off the Python code.\"></form>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "from IPython.display import HTML\n",
     "\n",
@@ -57,14 +83,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "This notebook was run on 2023-02-08 19:50:06 UTC +0000\n"
+      "This notebook was run on 2023-02-15 16:17:48 UTC +0000\n"
      ]
     }
    ],
@@ -96,7 +122,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 3,
    "metadata": {
     "scrolled": false
    },
@@ -105,7 +131,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "This notebook was run on 2023-02-08 20:04:53 UTC +0000\n",
+      "This notebook was run on 2023-02-15 16:17:50 UTC +0000\n",
       "Download skipped: No missing files!\n",
       "File downloaded\n"
      ]
@@ -141,174 +167,6 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Records with no value"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "slideshow": {
-     "slide_type": "fragment"
-    }
-   },
-   "source": [
-    "<div class=\"alert alert-block alert-danger\">\n",
-    "     \t&#10060; <b>Problem:</b> some records have missing data for all UPDRS-III variables.\n",
-    "</div>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "slideshow": {
-     "slide_type": "fragment"
-    }
-   },
-   "source": [
-    "Number of records with NaNs for all UPDRS-III variables:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "slideshow": {
-     "slide_type": "skip"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "updrs3_vars = [\n",
-    "    \"PDMEDDT\",\n",
-    "    \"PDMEDTM\",\n",
-    "    \"PDSTATE\",\n",
-    "    \"EXAMTM\",\n",
-    "    \"DBS_STATUS\",\n",
-    "    \"NP3SPCH\",\n",
-    "    \"NP3FACXP\",\n",
-    "    \"NP3RIGN\",\n",
-    "    \"NP3RIGRU\",\n",
-    "    \"NP3RIGLU\",\n",
-    "    \"NP3RIGRL\",\n",
-    "    \"NP3RIGLL\",\n",
-    "    \"NP3FTAPR\",\n",
-    "    \"NP3FTAPL\",\n",
-    "    \"NP3HMOVR\",\n",
-    "    \"NP3HMOVL\",\n",
-    "    \"NP3PRSPR\",\n",
-    "    \"NP3PRSPL\",\n",
-    "    \"NP3TTAPR\",\n",
-    "    \"NP3TTAPL\",\n",
-    "    \"NP3LGAGR\",\n",
-    "    \"NP3LGAGL\",\n",
-    "    \"NP3RISNG\",\n",
-    "    \"NP3GAIT\",\n",
-    "    \"NP3FRZGT\",\n",
-    "    \"NP3PSTBL\",\n",
-    "    \"NP3POSTR\",\n",
-    "    \"NP3BRADY\",\n",
-    "    \"NP3PTRMR\",\n",
-    "    \"NP3PTRML\",\n",
-    "    \"NP3KTRMR\",\n",
-    "    \"NP3KTRML\",\n",
-    "    \"NP3RTARU\",\n",
-    "    \"NP3RTALU\",\n",
-    "    \"NP3RTARL\",\n",
-    "    \"NP3RTALL\",\n",
-    "    \"NP3RTALJ\",\n",
-    "    \"NP3RTCON\",\n",
-    "    \"NP3TOT\",\n",
-    "    \"DYSKPRES\",\n",
-    "    \"DYSKIRAT\",\n",
-    "    \"NHY\",\n",
-    "    \"DBSONTM\",\n",
-    "    \"DBSOFFTM\",\n",
-    "    \"HRPOSTMED\",\n",
-    "    \"HRDBSOFF\",\n",
-    "    \"HRDBSON\",\n",
-    "]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "slideshow": {
-     "slide_type": "fragment"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "len(df[df[updrs3_vars].isnull().all(axis=1)])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "slideshow": {
-     "slide_type": "slide"
-    }
-   },
-   "source": [
-    "<div class=\"alert alert-block alert-success\">\n",
-    "     \t&#10003; <b>Proposed correction</b>: remove these records.\n",
-    "</div>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "slideshow": {
-     "slide_type": "fragment"
-    }
-   },
-   "source": [
-    "⚙️ Implementation\n",
-    "\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "slideshow": {
-     "slide_type": "fragment"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "df = df[df[updrs3_vars].notna().any(axis=1)]"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "slideshow": {
-     "slide_type": "fragment"
-    }
-   },
-   "source": [
-    "Updated number of records with NaNs for all UPDRS-III variables:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "scrolled": true,
-    "slideshow": {
-     "slide_type": "fragment"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "len(df[df[updrs3_vars].isnull().all(axis=1)])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "metadata": {
     "slideshow": {
      "slide_type": "fragment"
@@ -324,27 +182,99 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th>REC_ID</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>PDSTATE</th>\n",
+       "      <th>PDTRTMNT</th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th rowspan=\"2\" valign=\"top\">OFF</th>\n",
+       "      <th>0.0</th>\n",
+       "      <td>19</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1.0</th>\n",
+       "      <td>3739</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th rowspan=\"2\" valign=\"top\">ON</th>\n",
+       "      <th>0.0</th>\n",
+       "      <td>41</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1.0</th>\n",
+       "      <td>5774</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th rowspan=\"3\" valign=\"top\">NaN</th>\n",
+       "      <th>0.0</th>\n",
+       "      <td>8674</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1.0</th>\n",
+       "      <td>8</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>NaN</th>\n",
+       "      <td>2318</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                  REC_ID\n",
+       "PDSTATE PDTRTMNT        \n",
+       "OFF     0.0           19\n",
+       "        1.0         3739\n",
+       "ON      0.0           41\n",
+       "        1.0         5774\n",
+       "NaN     0.0         8674\n",
+       "        1.0            8\n",
+       "        NaN         2318"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "df.groupby([\"PDSTATE\", \"PDTRTMNT\"], dropna=False)[[\"REC_ID\"]].count()"
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {
-    "slideshow": {
-     "slide_type": "fragment"
-    }
-   },
-   "source": [
-    "The lines below show the difference between EXAMTM and PDMEDTM. All the records have a PDMEDTM that is earlier to EXAMTM by at most 5 hours:"
-   ]
-  },
-  {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {
     "scrolled": true
    },
@@ -352,7 +282,7 @@
    "source": [
     "errors = df[(df[\"PDSTATE\"] == \"ON\") & (df[\"PDTRTMNT\"] == 0)]\n",
     "# print the time difference between EXAMTM and PDMEDTM\n",
-    "(pd.to_datetime(errors[\"EXAMTM\"]) - pd.to_datetime(errors[\"PDMEDTM\"]))"
+    "#(pd.to_datetime(errors[\"ONEXAMTM\"]) - pd.to_datetime(errors[\"ONPDMEDTM\"]))"
    ]
   },
   {
@@ -382,7 +312,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -402,126 +332,91 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 7,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th>REC_ID</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>PDSTATE</th>\n",
+       "      <th>PDTRTMNT</th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th rowspan=\"2\" valign=\"top\">OFF</th>\n",
+       "      <th>0.0</th>\n",
+       "      <td>19</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1.0</th>\n",
+       "      <td>3739</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>ON</th>\n",
+       "      <th>1.0</th>\n",
+       "      <td>5815</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th rowspan=\"3\" valign=\"top\">NaN</th>\n",
+       "      <th>0.0</th>\n",
+       "      <td>8674</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1.0</th>\n",
+       "      <td>8</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>NaN</th>\n",
+       "      <td>2318</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                  REC_ID\n",
+       "PDSTATE PDTRTMNT        \n",
+       "OFF     0.0           19\n",
+       "        1.0         3739\n",
+       "ON      1.0         5815\n",
+       "NaN     0.0         8674\n",
+       "        1.0            8\n",
+       "        NaN         2318"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "df.groupby([\"PDSTATE\", \"PDTRTMNT\"], dropna=False)[[\"REC_ID\"]].count()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "slideshow": {
-     "slide_type": "slide"
-    }
-   },
-   "source": [
-    "## PDTRTMNT=0 and PDMEDTM not empty\n",
-    "\n",
-    "<div class=\"alert alert-block alert-danger\">\n",
-    " \t&#10060; <b>Problem:</b> some records have a non-empty PDMEDTIME and have PDTRTMNT=0, which is inconsistent.\n",
-    "    </div>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "slideshow": {
-     "slide_type": "fragment"
-    }
-   },
-   "source": [
-    "Number of records with a non-empty PDMEDTIME and PDTRTMNT=0:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "errors = df[(df[\"PDMEDTM\"].notnull()) & (df[\"PDTRTMNT\"] == 0)]\n",
-    "len(errors)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "slideshow": {
-     "slide_type": "fragment"
-    }
-   },
-   "source": [
-    "PDMEDTIME values for these records look plausible:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "slideshow": {
-     "slide_type": "fragment"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "from matplotlib import pyplot as plt\n",
-    "\n",
-    "pd.to_datetime(errors[\"PDMEDTM\"]).dt.hour.hist(bins=24, xrot=90, legend=True)\n",
-    "plt.xlabel(\"Hour of the day\")\n",
-    "plt.ylabel(\"Number of records\")\n",
-    "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "slideshow": {
-     "slide_type": "fragment"
-    }
-   },
-   "source": [
-    "<div class=\"alert alert-block alert-success\">\n",
-    "    \t&#10003; <b>Proposed correction:</b> set PDTRTMNT=1. It is unlikely that a plausible medication time was entered by mistake.\n",
-    "</div>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "slideshow": {
-     "slide_type": "slide"
-    }
-   },
-   "source": [
-    "⚙️ Implementation"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "df.loc[(df[\"PDTRTMNT\"] == 0) & (df[\"PDMEDTM\"].notnull()), \"PDTRTMNT\"] = 1"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Let's verify that the inconsistency is now fixed by counting the number of records with a non-empty PDMEDTIME and PDTRTMNT=0:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "errors = df[(df[\"PDMEDTM\"].notnull()) & (df[\"PDTRTMNT\"] == 0)]\n",
-    "len(errors)"
    ]
   },
   {
@@ -561,9 +456,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "9"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "len(df[(df[\"EVENT_ID\"] == \"SC\") & (df[\"PDTRTMNT\"] == 1)])"
    ]
@@ -614,9 +520,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "72"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# ON records\n",
     "on = df[df[\"PDSTATE\"] == \"ON\"]\n",
@@ -641,7 +558,7 @@
     "    return int(hour) * 3600 + int(mn) * 60 + int(sec)\n",
     "\n",
     "\n",
-    "on[\"delta\"] = on[\"EXAMTM\"].apply(to_secs) - on[\"PDMEDTM\"].apply(to_secs)\n",
+    "on[\"delta\"] = on[\"ONEXAMTM\"].apply(to_secs) - on[\"ONPDMEDTM\"].apply(to_secs)\n",
     "len(on[on[\"delta\"] < 0])"
    ]
   },
@@ -678,17 +595,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Removed 72 records where PDSTATE=ON and EXAMTM<PDMEDTM\n"
+     ]
+    }
+   ],
    "source": [
     "before = len(df)\n",
     "df = df[\n",
     "    ~(\n",
     "        (df[\"PDSTATE\"] == \"ON\")\n",
-    "        & df[\"EXAMTM\"].notnull()\n",
-    "        & df[\"PDMEDTM\"].notnull()\n",
-    "        & (df[\"EXAMTM\"] < df[\"PDMEDTM\"])\n",
+    "        & df[\"ONEXAMTM\"].notnull()\n",
+    "        & df[\"ONPDMEDTM\"].notnull()\n",
+    "        & (df[\"ONEXAMTM\"] < df[\"ONPDMEDTM\"])\n",
     "    )\n",
     "]\n",
     "print(f\"Removed {before-len(df)} records where PDSTATE=ON and EXAMTM<PDMEDTM\")"
@@ -731,9 +656,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "28"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "pb = df.groupby([\"PATNO\", \"EVENT_ID\"]).filter(lambda x: len(x) > 2)\n",
     "len(pb)"
@@ -747,17 +683,210 @@
     }
    },
    "source": [
-    "Each exams triple has an exam with missing EXAMTM and missing PDSTATE:"
+    "Each exams triple has an exam with missing ONEXAMTM, missing OFFEXAMTM, and missing PDSTATE:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th>EVENT_ID</th>\n",
+       "      <th>PDSTATE</th>\n",
+       "      <th>ONEXAMTM</th>\n",
+       "      <th>OFFEXAMTM</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <td>V16</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>V16</td>\n",
+       "      <td>ON</td>\n",
+       "      <td>09:36:00</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>V16</td>\n",
+       "      <td>ON</td>\n",
+       "      <td>09:36:00</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>V16</td>\n",
+       "      <td>OFF</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>08:35:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>V16</td>\n",
+       "      <td>OFF</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>08:35:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>V16</td>\n",
+       "      <td>OFF</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>10:48:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>V16</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>V16</td>\n",
+       "      <td>ON</td>\n",
+       "      <td>12:45:00</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>V16</td>\n",
+       "      <td>ON</td>\n",
+       "      <td>12:45:00</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>V16</td>\n",
+       "      <td>OFF</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>10:48:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>V14</td>\n",
+       "      <td>OFF</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>10:20:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>V14</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>V14</td>\n",
+       "      <td>OFF</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>10:20:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>V14</td>\n",
+       "      <td>ON</td>\n",
+       "      <td>12:00:00</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>V14</td>\n",
+       "      <td>ON</td>\n",
+       "      <td>12:00:00</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>V13</td>\n",
+       "      <td>OFF</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>09:18:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>V13</td>\n",
+       "      <td>ON</td>\n",
+       "      <td>10:40:00</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>V13</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>V13</td>\n",
+       "      <td>OFF</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>09:18:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>V13</td>\n",
+       "      <td>ON</td>\n",
+       "      <td>10:40:00</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>V12</td>\n",
+       "      <td>ON</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>V12</td>\n",
+       "      <td>OFF</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>10:05:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>V12</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>V12</td>\n",
+       "      <td>ON</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>V12</td>\n",
+       "      <td>OFF</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>10:05:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>V08</td>\n",
+       "      <td>ON</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>V08</td>\n",
+       "      <td>OFF</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>V08</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "pb = df.groupby([\"PATNO\", \"EVENT_ID\"]).filter(lambda x: len(x) > 2)\n",
-    "pb_trunc = pb[[\"EVENT_ID\", \"PDSTATE\", \"EXAMTM\"]]\n",
+    "pb_trunc = pb[[\"EVENT_ID\", \"PDSTATE\", \"ONEXAMTM\", \"OFFEXAMTM\"]]\n",
     "from IPython.display import HTML\n",
     "\n",
     "HTML(pb_trunc.to_html(index=False))"
@@ -772,7 +901,7 @@
    },
    "source": [
     "<div class=\"alert alert-block alert-success\">\n",
-    "  \t&#10003;   <b>Proposed correction:</b> remove exam with EXAMTM=NaN and PDSTATE=NaN when visit has 3 exams.\n",
+    "  \t&#10003;   <b>Proposed correction:</b> remove exam with ONEXAMTM=NaN and OFFEXAMTM=NaN and PDSTATE=NaN when visit has 3 exams.\n",
     "</div>"
    ]
   },
@@ -789,12 +918,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Number of removed records: 6\n"
+     ]
+    }
+   ],
    "source": [
     "a = df.groupby([\"PATNO\", \"EVENT_ID\"]).filter(lambda x: len(x) > 2)\n",
-    "index = (a[(a[\"PDSTATE\"].isnull()) & (a[\"EXAMTM\"].isnull())]).index\n",
+    "index = (a[(a[\"PDSTATE\"].isnull()) & (a[\"ONEXAMTM\"].isnull()) & (a[\"OFFEXAMTM\"].isnull())]).index\n",
     "\n",
     "before_len = len(df)\n",
     "df = df[~df.index.isin(index)]\n",
@@ -810,9 +947,341 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "20"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pb = df.groupby([\"PATNO\", \"EVENT_ID\"]).filter(lambda x: len(x) > 2)\n",
+    "len(pb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "There are still records that belong to a visit with more than 3 exams."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "source": [
+    "<div class=\"alert alert-block alert-success\">\n",
+    "  \t&#10003;   <b>Proposed correction:</b> remove duplicated records.\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "⚙️ Implementation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Number of removed records: 5\n"
+     ]
+    }
+   ],
+   "source": [
+    "before_len = len(df)\n",
+    "df = df[~df.drop([\"REC_ID\"], axis=1).duplicated(keep='first')]\n",
+    "print(f\"Number of removed records: {before_len-len(df)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "There are still records that belong to a visit with more than 3 exams. The corresponding visits all have 2 exams with PDSTATE=OFF, however, only one of these visits has HRPOSTMED != NaN. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>EVENT_ID</th>\n",
+       "      <th>PDSTATE</th>\n",
+       "      <th>HRPOSTMED</th>\n",
+       "      <th>OFFPDMEDDT</th>\n",
+       "      <th>OFFPDMEDTM</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>1273</th>\n",
+       "      <td>V16</td>\n",
+       "      <td>ON</td>\n",
+       "      <td>0.4500</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1275</th>\n",
+       "      <td>V16</td>\n",
+       "      <td>OFF</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>09/2021</td>\n",
+       "      <td>17:30:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1276</th>\n",
+       "      <td>V16</td>\n",
+       "      <td>OFF</td>\n",
+       "      <td>15.0833</td>\n",
+       "      <td>09/2021</td>\n",
+       "      <td>17:30:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>8923</th>\n",
+       "      <td>V16</td>\n",
+       "      <td>OFF</td>\n",
+       "      <td>11.8000</td>\n",
+       "      <td>04/2021</td>\n",
+       "      <td>23:00:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>8925</th>\n",
+       "      <td>V16</td>\n",
+       "      <td>ON</td>\n",
+       "      <td>1.5000</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>8927</th>\n",
+       "      <td>V16</td>\n",
+       "      <td>OFF</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>04/2021</td>\n",
+       "      <td>23:00:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>12593</th>\n",
+       "      <td>V14</td>\n",
+       "      <td>OFF</td>\n",
+       "      <td>13.3333</td>\n",
+       "      <td>01/2022</td>\n",
+       "      <td>21:00:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>12595</th>\n",
+       "      <td>V14</td>\n",
+       "      <td>OFF</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>01/2022</td>\n",
+       "      <td>21:00:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>12596</th>\n",
+       "      <td>V14</td>\n",
+       "      <td>ON</td>\n",
+       "      <td>1.5000</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>13982</th>\n",
+       "      <td>V13</td>\n",
+       "      <td>OFF</td>\n",
+       "      <td>11.3000</td>\n",
+       "      <td>09/2021</td>\n",
+       "      <td>22:00:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>13983</th>\n",
+       "      <td>V13</td>\n",
+       "      <td>ON</td>\n",
+       "      <td>1.0000</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>13985</th>\n",
+       "      <td>V13</td>\n",
+       "      <td>OFF</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>09/2021</td>\n",
+       "      <td>22:00:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>14674</th>\n",
+       "      <td>V12</td>\n",
+       "      <td>ON</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>14675</th>\n",
+       "      <td>V12</td>\n",
+       "      <td>OFF</td>\n",
+       "      <td>14.0833</td>\n",
+       "      <td>09/2020</td>\n",
+       "      <td>20:00:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>14678</th>\n",
+       "      <td>V12</td>\n",
+       "      <td>OFF</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>09/2020</td>\n",
+       "      <td>20:00:00</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "      EVENT_ID PDSTATE  HRPOSTMED OFFPDMEDDT OFFPDMEDTM\n",
+       "1273       V16      ON     0.4500        NaN        NaN\n",
+       "1275       V16     OFF        NaN    09/2021   17:30:00\n",
+       "1276       V16     OFF    15.0833    09/2021   17:30:00\n",
+       "8923       V16     OFF    11.8000    04/2021   23:00:00\n",
+       "8925       V16      ON     1.5000        NaN        NaN\n",
+       "8927       V16     OFF        NaN    04/2021   23:00:00\n",
+       "12593      V14     OFF    13.3333    01/2022   21:00:00\n",
+       "12595      V14     OFF        NaN    01/2022   21:00:00\n",
+       "12596      V14      ON     1.5000        NaN        NaN\n",
+       "13982      V13     OFF    11.3000    09/2021   22:00:00\n",
+       "13983      V13      ON     1.0000        NaN        NaN\n",
+       "13985      V13     OFF        NaN    09/2021   22:00:00\n",
+       "14674      V12      ON        NaN        NaN        NaN\n",
+       "14675      V12     OFF    14.0833    09/2020   20:00:00\n",
+       "14678      V12     OFF        NaN    09/2020   20:00:00"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pb = df.groupby([\"PATNO\", \"EVENT_ID\"]).filter(lambda x: len(x) > 2)\n",
+    "pb[[\"EVENT_ID\", \"PDSTATE\", \"HRPOSTMED\", \"OFFPDMEDDT\", \"OFFPDMEDTM\"]]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "source": [
+    "<div class=\"alert alert-block alert-success\">\n",
+    "  \t&#10003;   <b>Proposed correction:</b> remove exam with HRPOSTMED=NaN and PDSTATE=OFF when visit has 3 exams.\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "⚙️ Implementation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Number of removed records: 5\n"
+     ]
+    }
+   ],
+   "source": [
+    "\n",
+    "a = df.groupby([\"PATNO\", \"EVENT_ID\"]).filter(lambda x: len(x) > 2)\n",
+    "index = (a[(a[\"HRPOSTMED\"].isnull()) & (a[\"PDSTATE\"] == 'OFF')]).index\n",
+    "\n",
+    "before_len = len(df)\n",
+    "df = df[~df.index.isin(index)]\n",
+    "print(f\"Number of removed records: {before_len-len(df)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's verify that the inconsistency is solved by counting the number of records that belong to a visit with more than 3 exams:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "pb = df.groupby([\"PATNO\", \"EVENT_ID\"]).filter(lambda x: len(x) > 2)\n",
     "len(pb)"
@@ -851,11 +1320,89 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 19,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th>REC_ID</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>PDSTATE</th>\n",
+       "      <th>PDTRTMNT</th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th rowspan=\"2\" valign=\"top\">OFF</th>\n",
+       "      <th>0.0</th>\n",
+       "      <td>19</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1.0</th>\n",
+       "      <td>3734</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>ON</th>\n",
+       "      <th>1.0</th>\n",
+       "      <td>5738</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th rowspan=\"3\" valign=\"top\">NaN</th>\n",
+       "      <th>0.0</th>\n",
+       "      <td>8674</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1.0</th>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>NaN</th>\n",
+       "      <td>2318</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                  REC_ID\n",
+       "PDSTATE PDTRTMNT        \n",
+       "OFF     0.0           19\n",
+       "        1.0         3734\n",
+       "ON      1.0         5738\n",
+       "NaN     0.0         8674\n",
+       "        1.0            2\n",
+       "        NaN         2318"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "df.groupby([\"PDSTATE\", \"PDTRTMNT\"], dropna=False)[[\"REC_ID\"]].count()"
    ]
@@ -872,107 +1419,94 @@
     "\n",
     "|               |PDSTATE | PDTRTMNT | Number of records |\n",
     "|---------------|--------|----------|-------------------|\n",
-    "| **Case 1**  | OFF    | NaN      | 6                 |\n",
-    "| **Case 2** | NaN    | 0        | 6947          |\n",
-    "| **Case 3**|  NaN   | 1        | 633               |\n",
-    "| **Case 4** | NaN    | NaN      | 2322             |\n",
-    "| **Case 5**  | ON     | NaN      | 1                 |"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "slideshow": {
-     "slide_type": "slide"
-    }
-   },
-   "source": [
-    "## Case 1: PDSTATE=OFF and PDTRTMNT=NaN"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "slideshow": {
-     "slide_type": "fragment"
-    }
-   },
-   "source": [
-    "No record in case 1 has a medication date (PDMEDDT), a medication time (PDMEDTM), or\n",
-    "a DBS status (DBS_STATUS):"
+    "| **Case 1** | NaN    | 0        | 8674          |\n",
+    "| **Case 2**|  NaN   | 1        | 2               |\n",
+    "| **Case 3** | NaN    | NaN      | 2318             |"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 20,
    "metadata": {},
-   "outputs": [],
-   "source": [
-    "case_1 = df[(df[\"PDSTATE\"] == \"OFF\") & (df[\"PDTRTMNT\"].isnull())]\n",
-    "case_1.groupby(\n",
-    "    [\n",
-    "        \"PDMEDDT\",\n",
-    "        \"PDMEDTM\",\n",
-    "        \"DBS_STATUS\",\n",
-    "        \"HRPOSTMED\",\n",
-    "        \"DBSONTM\",\n",
-    "        \"DBSOFFTM\",\n",
-    "        \"HRDBSOFF\",\n",
-    "        \"HRDBSON\",\n",
-    "    ],\n",
-    "    dropna=False,\n",
-    ")[[\"REC_ID\"]].count()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "slideshow": {
-     "slide_type": "fragment"
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th>REC_ID</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>PDSTATE</th>\n",
+       "      <th>PDTRTMNT</th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th rowspan=\"2\" valign=\"top\">OFF</th>\n",
+       "      <th>0.0</th>\n",
+       "      <td>19</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1.0</th>\n",
+       "      <td>3734</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>ON</th>\n",
+       "      <th>1.0</th>\n",
+       "      <td>5738</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th rowspan=\"3\" valign=\"top\">NaN</th>\n",
+       "      <th>0.0</th>\n",
+       "      <td>8674</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1.0</th>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>NaN</th>\n",
+       "      <td>2318</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                  REC_ID\n",
+       "PDSTATE PDTRTMNT        \n",
+       "OFF     0.0           19\n",
+       "        1.0         3734\n",
+       "ON      1.0         5738\n",
+       "NaN     0.0         8674\n",
+       "        1.0            2\n",
+       "        NaN         2318"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
     }
-   },
-   "source": [
-    "<div class=\"alert alert-block alert-success\">\n",
-    " \t&#10003;    <b>Proposed correction</b>: set PDTRTMNT=0. It is unlikely that these records correspond to medicated patients when none of the variables related to medication have a value.\n",
-    "</div>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "slideshow": {
-     "slide_type": "slide"
-    }
-   },
-   "source": [
-    "⚙️ Implementation"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "df.loc[(df[\"PDSTATE\"] == \"OFF\") & (df[\"PDTRTMNT\"].isnull()), \"PDTRTMNT\"] = 0"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "slideshow": {
-     "slide_type": "fragment"
-    }
-   },
-   "source": [
-    "Let's verify that case 1 is now resolved:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   ],
    "source": [
     "df.groupby([\"PDSTATE\", \"PDTRTMNT\"], dropna=False)[[\"REC_ID\"]].count()"
    ]
@@ -985,7 +1519,7 @@
     }
    },
    "source": [
-    "## Case 2: PDSTATE=NaN and PDTRTMNT=0\n",
+    "## Case 1: PDSTATE=NaN and PDTRTMNT=0\n",
     "\n",
     "<div class=\"alert alert-block alert-success\">\n",
     "   \t&#10003;   <b>Proposed correction</b>: set PDSTATE=OFF. The patient is not medicated and for this reason PDSTATE is likely to not have been entered.\n",
@@ -1005,7 +1539,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1025,9 +1559,84 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 22,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th>REC_ID</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>PDSTATE</th>\n",
+       "      <th>PDTRTMNT</th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th rowspan=\"2\" valign=\"top\">OFF</th>\n",
+       "      <th>0.0</th>\n",
+       "      <td>8693</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1.0</th>\n",
+       "      <td>3734</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>ON</th>\n",
+       "      <th>1.0</th>\n",
+       "      <td>5738</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th rowspan=\"2\" valign=\"top\">NaN</th>\n",
+       "      <th>1.0</th>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>NaN</th>\n",
+       "      <td>2318</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                  REC_ID\n",
+       "PDSTATE PDTRTMNT        \n",
+       "OFF     0.0         8693\n",
+       "        1.0         3734\n",
+       "ON      1.0         5738\n",
+       "NaN     1.0            2\n",
+       "        NaN         2318"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "df.groupby([\"PDSTATE\", \"PDTRTMNT\"], dropna=False)[[\"REC_ID\"]].count()"
    ]
@@ -1040,222 +1649,20 @@
     }
    },
    "source": [
-    "## Case 3: PDSTATE=NaN and PDTRTMNT=1\n",
+    "## Case 2: PDSTATE=NaN and PDTRTMNT=1\n",
     "\n",
     "<div class=\"alert alert-block alert-success\">\n",
-    "    \t&#10003; <b>Proposed correction</b>: \n",
-    "    <ul>\n",
-    "        <li>(a) <b>IF</b> record belongs to a visit with two exams:</li>\n",
-    "            <ul>\n",
-    "                <li> Set PDSTATE=OFF for record with earliest EXAMTM</li>\n",
-    "                <li> Set PDSTATE=ON for record with latest EXAMTM</li>\n",
-    "            </ul>\n",
-    "        <li>(b) <b>ELSE</b>: determine PDSTATE as a function of PDMEDTM and EXAMTM:</li>\n",
-    "            <ul>\n",
-    "                <li>(i) <b>IF</b> PDMEDTM or EXAMTM are missing <b>THEN</b> discard record.</li>\n",
-    "                <li> (ii) <b>IF</b> PDMEDTM is earlier than EXAMTM:</li>\n",
-    "                    <ul>\n",
-    "                        <li><b>IF</b> EXAMTM-PDMEDTM < 6 hours (PPMI cut-off)<b>THEN</b>:\n",
-    "                <ul><li><b>IF</b> EXAMTM-PDMEDTM >= 30 min <b>THEN</b> set PDSTATE=ON.</li>\n",
-    "                    <li><b>ELSE</b>: discard record.</ul>\n",
-    "        <li><b>ELSE:</b> set PDSTATE=OFF</li>\n",
-    "                    </ul>\n",
-    "                <li> (iii) <b>IF</b> PDMEDTM is later than EXAMTM <b>THEN</b>:\n",
-    "                    <UL>\n",
-    "                        <li>(a) <b>IF</b> PDMEDTM is later than 4pm <b>THEN</b> assume record belongs to the previous day, set PDSTATE=OFF.</li>\n",
-    "                        <li>(b) <b>ELSE</b>                     \n",
-    "                    discard record.\n",
-    "                            </ul></li>\n",
-    "    </ul>\n",
-    "    \n",
-    "    \n",
-    "  \n",
+    "    \t&#10003; <b>Proposed correction</b>: drop the record as there are only 2 of them. \n",
     "</div>"
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {
-    "slideshow": {
-     "slide_type": "slide"
-    }
-   },
-   "source": [
-    "⚙️ Implementation\n",
-    "\n",
-    "Let's implement each sub-case separately."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Case 3.a: visits with two exams"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Let's count the number of records in case 3.a:"
-   ]
-  },
-  {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [],
    "source": [
-    "case_3 = (df[\"PDSTATE\"].isnull()) & (df[\"PDTRTMNT\"] == 1)\n",
-    "a = df[case_3].groupby([\"PATNO\", \"EVENT_ID\"]).filter(lambda x: len(x) == 2)\n",
-    "print(f\"Found {len(a)} records in Case 3.a\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Case 3.b.i: visits with one exam, missing EXAMTM or PDMEDTM"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Number of records in case 3.b with missing EXAMTM or missing PDMEDTM:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "len(df[case_3 & ((df[\"EXAMTM\"].isnull()) | (df[\"PDMEDTM\"].isnull()))])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "before_len = len(df)\n",
-    "df.drop(\n",
-    "    df[case_3 & ((df[\"EXAMTM\"].isnull()) | (df[\"PDMEDTM\"].isnull()))].index,\n",
-    "    inplace=True,\n",
-    ")\n",
-    "print(f\"Removed {before_len-len(df)} record(s) with missing EXAMTM or PDMEDTM\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Updated records distribution in case 3:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "df.groupby([\"PDSTATE\", \"PDTRTMNT\"], dropna=False)[[\"REC_ID\"]].count()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "case_3 = (df[\"PDSTATE\"].isnull()) & (df[\"PDTRTMNT\"] == 1)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Case 3.b.ii: visits with one exam, PDMEDTM earlier than EXAMTM"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Number of records in case 3.b where PDMEDTM is earlier or equal to EXAMTM:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "len(df[case_3 & (df[\"PDMEDTM\"] <= df[\"EXAMTM\"])])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "def to_secs(x):\n",
-    "    if str(x) == \"nan\":\n",
-    "        import numpy as np\n",
-    "\n",
-    "        return np.NaN\n",
-    "    try:\n",
-    "        hour, mn, sec = x.split(\":\")\n",
-    "    except Exception as e:\n",
-    "        print(f'Cannot process \"{x}\"')\n",
-    "        raise (e)\n",
-    "    return int(hour) * 3600 + int(mn) * 60 + int(sec)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Number of records in case 3.b where PDMEDTM is earlier or equal to EXAMTM and $30\\,min \\le \\text{EXAMTM}-\\text{PDMEDTM} < 6\\,hours$:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "len(\n",
-    "    df[\n",
-    "        case_3\n",
-    "        & (df[\"EXAMTM\"].apply(to_secs) - df[\"PDMEDTM\"].apply(to_secs) >= 1800)\n",
-    "        & (df[\"EXAMTM\"].apply(to_secs) - df[\"PDMEDTM\"].apply(to_secs) < 6 * 3600)\n",
-    "    ]\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Let's set PDSTATE=ON for these records."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "df.loc[\n",
-    "    case_3\n",
-    "    & (df[\"EXAMTM\"].apply(to_secs) - df[\"PDMEDTM\"].apply(to_secs) >= 1800)\n",
-    "    & (df[\"EXAMTM\"].apply(to_secs) - df[\"PDMEDTM\"].apply(to_secs) < 6 * 3600),\n",
-    "    \"PDSTATE\",\n",
-    "] = \"ON\""
+    "df = df[~(df['PDSTATE'].isnull()) | (df['PDTRTMNT']!=1)]"
    ]
   },
   {
@@ -1267,377 +1674,329 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th>REC_ID</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>PDSTATE</th>\n",
+       "      <th>PDTRTMNT</th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th rowspan=\"2\" valign=\"top\">OFF</th>\n",
+       "      <th>0.0</th>\n",
+       "      <td>8693</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1.0</th>\n",
+       "      <td>3734</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>ON</th>\n",
+       "      <th>1.0</th>\n",
+       "      <td>5738</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>NaN</th>\n",
+       "      <th>NaN</th>\n",
+       "      <td>2318</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                  REC_ID\n",
+       "PDSTATE PDTRTMNT        \n",
+       "OFF     0.0         8693\n",
+       "        1.0         3734\n",
+       "ON      1.0         5738\n",
+       "NaN     NaN         2318"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.groupby([\"PDSTATE\", \"PDTRTMNT\"], dropna=False)[[\"REC_ID\"]].count()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "## Case 3: PDSTATE=NaN and PDTRTMNT=NaN\n",
+    "\n",
+    "Similar to case 1, no record in case 3 has a medication date (ON/OFFPDMEDDT), a medication time (ON/OFFPDMEDTM), or\n",
+    "a DBS status (DBSYN):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [],
-   "source": [
-    "df.groupby([\"PDSTATE\", \"PDTRTMNT\"], dropna=False)[[\"REC_ID\"]].count()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "case_3 = (df[\"PDSTATE\"].isnull()) & (df[\"PDTRTMNT\"] == 1)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Number of records in case 3.b where PDMEDTM is earlier or equal to EXAMTM and $\\text{EXAMTM-PDMEDTM} < 30\\,min$:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "len(\n",
-    "    df[\n",
-    "        case_3\n",
-    "        & (df[\"EXAMTM\"].apply(to_secs) - df[\"PDMEDTM\"].apply(to_secs) < 1800)\n",
-    "        & (df[\"EXAMTM\"].apply(to_secs) - df[\"PDMEDTM\"].apply(to_secs) >= 0)\n",
-    "    ]\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Let's discard these records:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "df.drop(\n",
-    "    df[\n",
-    "        case_3\n",
-    "        & (df[\"EXAMTM\"].apply(to_secs) - df[\"PDMEDTM\"].apply(to_secs) < 1800)\n",
-    "        & (df[\"EXAMTM\"].apply(to_secs) - df[\"PDMEDTM\"].apply(to_secs) >= 0)\n",
-    "    ].index,\n",
-    "    inplace=True,\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Updated records distribution:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "df.groupby([\"PDSTATE\", \"PDTRTMNT\"], dropna=False)[[\"REC_ID\"]].count()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "case_3 = (df[\"PDSTATE\"].isnull()) & (df[\"PDTRTMNT\"] == 1)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Number of records in case 3.b where PDMEDTM is earlier or equal to EXAMTM and $\\text{EXAMTM-PDMEDTM} \\ge 6\\,hours$:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "len(\n",
-    "    df[\n",
-    "        case_3\n",
-    "        & (df[\"EXAMTM\"].apply(to_secs) - df[\"PDMEDTM\"].apply(to_secs) >= 6 * 3600)\n",
-    "    ]\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Let's set PDSTATE=OFF for these records."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "df.loc[\n",
-    "    case_3 & (df[\"EXAMTM\"].apply(to_secs) - df[\"PDMEDTM\"].apply(to_secs) >= 6 * 3600),\n",
-    "    \"PDSTATE\",\n",
-    "] = \"OFF\""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Updated records distribution:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "df.groupby([\"PDSTATE\", \"PDTRTMNT\"], dropna=False)[[\"REC_ID\"]].count()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Case 3.b.iii: PDMEDTM is later than EXAMTM"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Number of records in case 3.b where PDMEDTM is later than EXAMTM:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "case_3 = (df[\"PDSTATE\"].isnull()) & (df[\"PDTRTMNT\"] == 1)\n",
-    "len(df[case_3 & (df[\"PDMEDTM\"] > df[\"EXAMTM\"])])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "#### Case 3.b.iii.a: PDMEDTM is after 4pm"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Some of records have a PDMEDTIME which likely belongs to the previous day but there is no way to confirm it because dates only include a month, a year, but no day. Looking at the distribution of exam times in such cases, we noticed that no exam took place after 4pm, which motivates the use of 4pm as cut-off time."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Distribution of EXAM times when $\\text{PDMEDTM} > \\text{EXAMTM}$:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import numpy as np\n",
-    "\n",
-    "pd.to_datetime(\n",
-    "    df[case_3 & (df[\"PDMEDTM\"].apply(to_secs) > df[\"EXAMTM\"].apply(to_secs))][\"EXAMTM\"]\n",
-    ").dt.hour.hist(bins=np.arange(24))\n",
-    "plt.xlabel(\"Hour of the day\")\n",
-    "plt.ylabel(\"Number of EXAMTM records\");"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Number of records in case 3 where PDMEDTM is after EXAMTM and PDMEDTM is after 4pm:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "len(\n",
-    "    df[\n",
-    "        case_3\n",
-    "        & (df[\"PDMEDTM\"].apply(to_secs) > df[\"EXAMTM\"].apply(to_secs))\n",
-    "        & (df[\"PDMEDTM\"] > \"16:00:00\")\n",
-    "    ]\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Let's set PDSTATE=OFF for these records:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "df.loc[\n",
-    "    case_3\n",
-    "    & (df[\"PDMEDTM\"].apply(to_secs) > df[\"EXAMTM\"].apply(to_secs))\n",
-    "    & (df[\"PDMEDTM\"] > \"16:00:00\"),\n",
-    "    \"PDSTATE\",\n",
-    "] = \"OFF\""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Updated records distribution:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "df.groupby([\"PDSTATE\", \"PDTRTMNT\"], dropna=False)[[\"REC_ID\"]].count()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "case_3 = (df[\"PDSTATE\"].isnull()) & (df[\"PDTRTMNT\"] == 1)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "#### Case 3.b.iii.a: PDMEDTM is before 4pm"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Number of records in case 3 where PDMEDTM is later than EXAMTM and PDMEDTM is before 4pm:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "len(df[case_3 & (df[\"EXAMTM\"].apply(to_secs) < df[\"PDMEDTM\"].apply(to_secs))])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Let's remove these records. "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "df.drop(\n",
-    "    df[case_3 & (df[\"EXAMTM\"].apply(to_secs) < df[\"PDMEDTM\"].apply(to_secs))].index,\n",
-    "    inplace=True,\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "case_3 = (df[\"PDSTATE\"].isnull()) & (df[\"PDTRTMNT\"] == 1)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "slideshow": {
-     "slide_type": "slide"
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th>REC_ID</th>\n",
+       "      <th>PATNO</th>\n",
+       "      <th>EVENT_ID</th>\n",
+       "      <th>PAG_NAME</th>\n",
+       "      <th>INFODT</th>\n",
+       "      <th>PDTRTMNT</th>\n",
+       "      <th>PDSTATE</th>\n",
+       "      <th>PDMEDYN</th>\n",
+       "      <th>NTEXAMDT</th>\n",
+       "      <th>NTEXAMTM</th>\n",
+       "      <th>...</th>\n",
+       "      <th>NP3RTARL</th>\n",
+       "      <th>NP3RTALL</th>\n",
+       "      <th>NP3RTALJ</th>\n",
+       "      <th>NP3RTCON</th>\n",
+       "      <th>NP3TOT</th>\n",
+       "      <th>DYSKPRES</th>\n",
+       "      <th>DYSKIRAT</th>\n",
+       "      <th>NHY</th>\n",
+       "      <th>ORIG_ENTRY</th>\n",
+       "      <th>LAST_UPDATE</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>OFFPDMEDDT</th>\n",
+       "      <th>OFFPDMEDTM</th>\n",
+       "      <th>ONPDMEDDT</th>\n",
+       "      <th>ONPDMEDTM</th>\n",
+       "      <th>DBSYN</th>\n",
+       "      <th>HRPOSTMED</th>\n",
+       "      <th>DBSONTM</th>\n",
+       "      <th>DBSOFFTM</th>\n",
+       "      <th>HRDBSOFF</th>\n",
+       "      <th>HRDBSON</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>NaN</th>\n",
+       "      <th>NaN</th>\n",
+       "      <th>NaN</th>\n",
+       "      <th>NaN</th>\n",
+       "      <th>0.0</th>\n",
+       "      <th>NaN</th>\n",
+       "      <th>NaN</th>\n",
+       "      <th>NaN</th>\n",
+       "      <th>NaN</th>\n",
+       "      <th>NaN</th>\n",
+       "      <td>2318</td>\n",
+       "      <td>2318</td>\n",
+       "      <td>2318</td>\n",
+       "      <td>2318</td>\n",
+       "      <td>2318</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>2318</td>\n",
+       "      <td>1135</td>\n",
+       "      <td>...</td>\n",
+       "      <td>2317</td>\n",
+       "      <td>2317</td>\n",
+       "      <td>2317</td>\n",
+       "      <td>2316</td>\n",
+       "      <td>2310</td>\n",
+       "      <td>2316</td>\n",
+       "      <td>39</td>\n",
+       "      <td>2316</td>\n",
+       "      <td>2318</td>\n",
+       "      <td>2318</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>1 rows × 58 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                                                                             REC_ID  \\\n",
+       "OFFPDMEDDT OFFPDMEDTM ONPDMEDDT ONPDMEDTM DBSYN HRPOSTMED DBSONTM DBSOFFTM HRDBSOFF HRDBSON           \n",
+       "NaN        NaN        NaN       NaN       0.0   NaN       NaN     NaN      NaN      NaN        2318   \n",
+       "\n",
+       "                                                                                             PATNO  \\\n",
+       "OFFPDMEDDT OFFPDMEDTM ONPDMEDDT ONPDMEDTM DBSYN HRPOSTMED DBSONTM DBSOFFTM HRDBSOFF HRDBSON          \n",
+       "NaN        NaN        NaN       NaN       0.0   NaN       NaN     NaN      NaN      NaN       2318   \n",
+       "\n",
+       "                                                                                             EVENT_ID  \\\n",
+       "OFFPDMEDDT OFFPDMEDTM ONPDMEDDT ONPDMEDTM DBSYN HRPOSTMED DBSONTM DBSOFFTM HRDBSOFF HRDBSON             \n",
+       "NaN        NaN        NaN       NaN       0.0   NaN       NaN     NaN      NaN      NaN          2318   \n",
+       "\n",
+       "                                                                                             PAG_NAME  \\\n",
+       "OFFPDMEDDT OFFPDMEDTM ONPDMEDDT ONPDMEDTM DBSYN HRPOSTMED DBSONTM DBSOFFTM HRDBSOFF HRDBSON             \n",
+       "NaN        NaN        NaN       NaN       0.0   NaN       NaN     NaN      NaN      NaN          2318   \n",
+       "\n",
+       "                                                                                             INFODT  \\\n",
+       "OFFPDMEDDT OFFPDMEDTM ONPDMEDDT ONPDMEDTM DBSYN HRPOSTMED DBSONTM DBSOFFTM HRDBSOFF HRDBSON           \n",
+       "NaN        NaN        NaN       NaN       0.0   NaN       NaN     NaN      NaN      NaN        2318   \n",
+       "\n",
+       "                                                                                             PDTRTMNT  \\\n",
+       "OFFPDMEDDT OFFPDMEDTM ONPDMEDDT ONPDMEDTM DBSYN HRPOSTMED DBSONTM DBSOFFTM HRDBSOFF HRDBSON             \n",
+       "NaN        NaN        NaN       NaN       0.0   NaN       NaN     NaN      NaN      NaN             0   \n",
+       "\n",
+       "                                                                                             PDSTATE  \\\n",
+       "OFFPDMEDDT OFFPDMEDTM ONPDMEDDT ONPDMEDTM DBSYN HRPOSTMED DBSONTM DBSOFFTM HRDBSOFF HRDBSON            \n",
+       "NaN        NaN        NaN       NaN       0.0   NaN       NaN     NaN      NaN      NaN            0   \n",
+       "\n",
+       "                                                                                             PDMEDYN  \\\n",
+       "OFFPDMEDDT OFFPDMEDTM ONPDMEDDT ONPDMEDTM DBSYN HRPOSTMED DBSONTM DBSOFFTM HRDBSOFF HRDBSON            \n",
+       "NaN        NaN        NaN       NaN       0.0   NaN       NaN     NaN      NaN      NaN            0   \n",
+       "\n",
+       "                                                                                             NTEXAMDT  \\\n",
+       "OFFPDMEDDT OFFPDMEDTM ONPDMEDDT ONPDMEDTM DBSYN HRPOSTMED DBSONTM DBSOFFTM HRDBSOFF HRDBSON             \n",
+       "NaN        NaN        NaN       NaN       0.0   NaN       NaN     NaN      NaN      NaN          2318   \n",
+       "\n",
+       "                                                                                             NTEXAMTM  \\\n",
+       "OFFPDMEDDT OFFPDMEDTM ONPDMEDDT ONPDMEDTM DBSYN HRPOSTMED DBSONTM DBSOFFTM HRDBSOFF HRDBSON             \n",
+       "NaN        NaN        NaN       NaN       0.0   NaN       NaN     NaN      NaN      NaN          1135   \n",
+       "\n",
+       "                                                                                             ...  \\\n",
+       "OFFPDMEDDT OFFPDMEDTM ONPDMEDDT ONPDMEDTM DBSYN HRPOSTMED DBSONTM DBSOFFTM HRDBSOFF HRDBSON  ...   \n",
+       "NaN        NaN        NaN       NaN       0.0   NaN       NaN     NaN      NaN      NaN      ...   \n",
+       "\n",
+       "                                                                                             NP3RTARL  \\\n",
+       "OFFPDMEDDT OFFPDMEDTM ONPDMEDDT ONPDMEDTM DBSYN HRPOSTMED DBSONTM DBSOFFTM HRDBSOFF HRDBSON             \n",
+       "NaN        NaN        NaN       NaN       0.0   NaN       NaN     NaN      NaN      NaN          2317   \n",
+       "\n",
+       "                                                                                             NP3RTALL  \\\n",
+       "OFFPDMEDDT OFFPDMEDTM ONPDMEDDT ONPDMEDTM DBSYN HRPOSTMED DBSONTM DBSOFFTM HRDBSOFF HRDBSON             \n",
+       "NaN        NaN        NaN       NaN       0.0   NaN       NaN     NaN      NaN      NaN          2317   \n",
+       "\n",
+       "                                                                                             NP3RTALJ  \\\n",
+       "OFFPDMEDDT OFFPDMEDTM ONPDMEDDT ONPDMEDTM DBSYN HRPOSTMED DBSONTM DBSOFFTM HRDBSOFF HRDBSON             \n",
+       "NaN        NaN        NaN       NaN       0.0   NaN       NaN     NaN      NaN      NaN          2317   \n",
+       "\n",
+       "                                                                                             NP3RTCON  \\\n",
+       "OFFPDMEDDT OFFPDMEDTM ONPDMEDDT ONPDMEDTM DBSYN HRPOSTMED DBSONTM DBSOFFTM HRDBSOFF HRDBSON             \n",
+       "NaN        NaN        NaN       NaN       0.0   NaN       NaN     NaN      NaN      NaN          2316   \n",
+       "\n",
+       "                                                                                             NP3TOT  \\\n",
+       "OFFPDMEDDT OFFPDMEDTM ONPDMEDDT ONPDMEDTM DBSYN HRPOSTMED DBSONTM DBSOFFTM HRDBSOFF HRDBSON           \n",
+       "NaN        NaN        NaN       NaN       0.0   NaN       NaN     NaN      NaN      NaN        2310   \n",
+       "\n",
+       "                                                                                             DYSKPRES  \\\n",
+       "OFFPDMEDDT OFFPDMEDTM ONPDMEDDT ONPDMEDTM DBSYN HRPOSTMED DBSONTM DBSOFFTM HRDBSOFF HRDBSON             \n",
+       "NaN        NaN        NaN       NaN       0.0   NaN       NaN     NaN      NaN      NaN          2316   \n",
+       "\n",
+       "                                                                                             DYSKIRAT  \\\n",
+       "OFFPDMEDDT OFFPDMEDTM ONPDMEDDT ONPDMEDTM DBSYN HRPOSTMED DBSONTM DBSOFFTM HRDBSOFF HRDBSON             \n",
+       "NaN        NaN        NaN       NaN       0.0   NaN       NaN     NaN      NaN      NaN            39   \n",
+       "\n",
+       "                                                                                              NHY  \\\n",
+       "OFFPDMEDDT OFFPDMEDTM ONPDMEDDT ONPDMEDTM DBSYN HRPOSTMED DBSONTM DBSOFFTM HRDBSOFF HRDBSON         \n",
+       "NaN        NaN        NaN       NaN       0.0   NaN       NaN     NaN      NaN      NaN      2316   \n",
+       "\n",
+       "                                                                                             ORIG_ENTRY  \\\n",
+       "OFFPDMEDDT OFFPDMEDTM ONPDMEDDT ONPDMEDTM DBSYN HRPOSTMED DBSONTM DBSOFFTM HRDBSOFF HRDBSON               \n",
+       "NaN        NaN        NaN       NaN       0.0   NaN       NaN     NaN      NaN      NaN            2318   \n",
+       "\n",
+       "                                                                                             LAST_UPDATE  \n",
+       "OFFPDMEDDT OFFPDMEDTM ONPDMEDDT ONPDMEDTM DBSYN HRPOSTMED DBSONTM DBSOFFTM HRDBSOFF HRDBSON               \n",
+       "NaN        NaN        NaN       NaN       0.0   NaN       NaN     NaN      NaN      NaN             2318  \n",
+       "\n",
+       "[1 rows x 58 columns]"
+      ]
+     },
+     "execution_count": 25,
+     "metadata": {},
+     "output_type": "execute_result"
     }
-   },
+   ],
    "source": [
-    "Let's verify that case 3 (PDSTATE=NaN, PDTRTMNT=1) is now resolved:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "df.groupby([\"PDSTATE\", \"PDTRTMNT\"], dropna=False)[[\"REC_ID\"]].count()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "slideshow": {
-     "slide_type": "slide"
-    }
-   },
-   "source": [
-    "## Case 4: PDSTATE=NaN and PDTRTMNT=NaN\n",
-    "\n",
-    "Similar to case 1, no record in case 4 has a medication date (PDMEDDT), a medication time (PDMEDTM), or\n",
-    "a DBS status (DBS_STATUS):"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "scrolled": true
-   },
-   "outputs": [],
-   "source": [
-    "case_4 = df[(df[\"PDSTATE\"].isnull()) & (df[\"PDTRTMNT\"].isnull())]\n",
-    "case_4.groupby(\n",
+    "case_3 = df[(df[\"PDSTATE\"].isnull()) & (df[\"PDTRTMNT\"].isnull())]\n",
+    "case_3.groupby(\n",
     "    [\n",
-    "        \"PDMEDDT\",\n",
-    "        \"PDMEDTM\",\n",
-    "        \"DBS_STATUS\",\n",
+    "        \"OFFPDMEDDT\",\n",
+    "        \"OFFPDMEDTM\",\n",
+    "        \"ONPDMEDDT\",\n",
+    "        \"ONPDMEDTM\",\n",
+    "        \"DBSYN\",\n",
     "        \"HRPOSTMED\",\n",
     "        \"DBSONTM\",\n",
     "        \"DBSOFFTM\",\n",
@@ -1657,7 +2016,7 @@
    },
    "source": [
     "<div class=\"alert alert-block alert-success\">\n",
-    "    \t&#10003; <b>Proposed solution</b>: set PDSTATE=OFF and PDTRTMNT=0. It is very unlikely that the patient was medicated and none of the 8 medication-related variables were set.\n",
+    "    \t&#10003; <b>Proposed solution</b>: set PDSTATE=OFF and PDTRTMNT=0. It is very unlikely that the patient was medicated and none of the medication-related variables were set.\n",
     "</div>"
    ]
   },
@@ -1674,7 +2033,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1692,74 +2051,78 @@
     }
    },
    "source": [
-    "Let's verify that case 4 is now resolved:"
+    "Let's verify that case 3 is now resolved:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 27,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [],
-   "source": [
-    "df.groupby([\"PDSTATE\", \"PDTRTMNT\"], dropna=False)[[\"REC_ID\"]].count()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "slideshow": {
-     "slide_type": "slide"
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th>REC_ID</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>PDSTATE</th>\n",
+       "      <th>PDTRTMNT</th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th rowspan=\"2\" valign=\"top\">OFF</th>\n",
+       "      <th>0.0</th>\n",
+       "      <td>11011</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1.0</th>\n",
+       "      <td>3734</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>ON</th>\n",
+       "      <th>1.0</th>\n",
+       "      <td>5738</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                  REC_ID\n",
+       "PDSTATE PDTRTMNT        \n",
+       "OFF     0.0        11011\n",
+       "        1.0         3734\n",
+       "ON      1.0         5738"
+      ]
+     },
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
     }
-   },
-   "source": [
-    "## Case 5: PDSTATE=ON and PDTRTMNT=NaN\n",
-    "\n",
-    "\n",
-    "<div class=\"alert alert-block alert-success\">\n",
-    "    \t&#10003; <b>Proposed correction</b>: set PDTRTMNT=1. The patient is medicated since PDSTATE=ON.\n",
-    "</div>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "slideshow": {
-     "slide_type": "fragment"
-    }
-   },
-   "source": [
-    "⚙️ Implementation"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "df.loc[(df[\"PDSTATE\"] == \"ON\") & (df[\"PDTRTMNT\"].isnull()), \"PDTRTMNT\"] = 1"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "slideshow": {
-     "slide_type": "fragment"
-    }
-   },
-   "source": [
-    "Let's verify that case 5 is now resolved:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "scrolled": true
-   },
-   "outputs": [],
+   ],
    "source": [
     "df.groupby([\"PDSTATE\", \"PDTRTMNT\"], dropna=False)[[\"REC_ID\"]].count()"
    ]
@@ -1779,12 +2142,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 28,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Cleaned file saved in MDS_UPDRS_Part_III_clean.csv\n"
+     ]
+    }
+   ],
    "source": [
     "filename = \"MDS_UPDRS_Part_III_clean.csv\"\n",
-    "df.to_csv(op.join(data_dir, filename), index=False)\n",
+    "df.to_csv(os.path.join(utils.study_files_dir, filename), index=False)\n",
     "print(f\"Cleaned file saved in {filename}\")"
    ]
   },
@@ -1814,9 +2185,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 29,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 29,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "a = df.groupby([\"PATNO\", \"EVENT_ID\"]).filter(lambda x: len(x) == 2)\n",
     "a.groupby([\"PATNO\", \"EVENT_ID\"]).filter(\n",
@@ -1828,18 +2210,29 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**IF** PDSTATE=ON **THEN** EXAMTM>PDMEDTM"
+    "**IF** PDSTATE=ON **THEN** ONEXAMTM>ONPDMEDTM"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 30,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 30,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "df[\n",
     "    (df[\"PDSTATE\"] == \"ON\")\n",
-    "    & (df[\"EXAMTM\"].apply(to_secs) < df[\"PDMEDTM\"].apply(to_secs))\n",
+    "    & (df[\"ONEXAMTM\"].apply(to_secs) < df[\"ONPDMEDTM\"].apply(to_secs))\n",
     "].empty"
    ]
   },
@@ -1847,14 +2240,22 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**IF** PDTRTMNT=0 **THEN** there is a single visit and PDSTATE=off"
+    "**IF** PDTRTMNT=0 **THEN** there is a single visit and PDSTATE=OFF"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 31,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "True\n"
+     ]
+    }
+   ],
    "source": [
     "assert (\n",
     "    df[df[\"PDTRTMNT\"] == 0]\n",
@@ -1880,9 +2281,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 32,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 32,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "def wrong_pairs(x):\n",
     "    rows = [row for index, row in x.iterrows()]\n",
@@ -1908,48 +2320,6 @@
     "    \"PATNO\"\n",
     ").filter(wrong_pairs).empty"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "scrolled": true
-   },
-   "outputs": [],
-   "source": [
-    "# off = (df['PDSTATE']=='OFF') & (df['PDMEDTM']<='16:00:00')\n",
-    "# df['EXAMsecs'] = df[off]['EXAMTM'].apply(to_secs)\n",
-    "# df['PDMEDTMsecs'] = df[off]['PDMEDTM'].apply(to_secs)\n",
-    "\n",
-    "# df[off & (df['EXAMsecs']-df['PDMEDTMsecs']>=0) & (df['EXAMsecs']-df['PDMEDTMsecs']<6*3600)]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# off = (df['PDSTATE']=='OFF') & (df['PDMEDTM']<='16:00:00')\n",
-    "# df['EXAMsecs'] = df[off]['EXAMTM'].apply(to_secs)\n",
-    "# df['PDMEDTMsecs'] = df[off]['PDMEDTM'].apply(to_secs)\n",
-    "\n",
-    "# df[off & (df['EXAMsecs']-df['PDMEDTMsecs']>=0) & (df['EXAMsecs']-df['PDMEDTMsecs']<6*3600)]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/livingpark_utils/notebooks/pd_status.ipynb
+++ b/livingpark_utils/notebooks/pd_status.ipynb
@@ -282,7 +282,7 @@
    "source": [
     "errors = df[(df[\"PDSTATE\"] == \"ON\") & (df[\"PDTRTMNT\"] == 0)]\n",
     "# print the time difference between EXAMTM and PDMEDTM\n",
-    "#(pd.to_datetime(errors[\"ONEXAMTM\"]) - pd.to_datetime(errors[\"ONPDMEDTM\"]))"
+    "# (pd.to_datetime(errors[\"ONEXAMTM\"]) - pd.to_datetime(errors[\"ONPDMEDTM\"]))"
    ]
   },
   {
@@ -931,7 +931,9 @@
    ],
    "source": [
     "a = df.groupby([\"PATNO\", \"EVENT_ID\"]).filter(lambda x: len(x) > 2)\n",
-    "index = (a[(a[\"PDSTATE\"].isnull()) & (a[\"ONEXAMTM\"].isnull()) & (a[\"OFFEXAMTM\"].isnull())]).index\n",
+    "index = (\n",
+    "    a[(a[\"PDSTATE\"].isnull()) & (a[\"ONEXAMTM\"].isnull()) & (a[\"OFFEXAMTM\"].isnull())]\n",
+    ").index\n",
     "\n",
     "before_len = len(df)\n",
     "df = df[~df.index.isin(index)]\n",
@@ -1012,7 +1014,7 @@
    ],
    "source": [
     "before_len = len(df)\n",
-    "df = df[~df.drop([\"REC_ID\"], axis=1).duplicated(keep='first')]\n",
+    "df = df[~df.drop([\"REC_ID\"], axis=1).duplicated(keep=\"first\")]\n",
     "print(f\"Number of removed records: {before_len-len(df)}\")"
    ]
   },
@@ -1250,9 +1252,8 @@
     }
    ],
    "source": [
-    "\n",
     "a = df.groupby([\"PATNO\", \"EVENT_ID\"]).filter(lambda x: len(x) > 2)\n",
-    "index = (a[(a[\"HRPOSTMED\"].isnull()) & (a[\"PDSTATE\"] == 'OFF')]).index\n",
+    "index = (a[(a[\"HRPOSTMED\"].isnull()) & (a[\"PDSTATE\"] == \"OFF\")]).index\n",
     "\n",
     "before_len = len(df)\n",
     "df = df[~df.index.isin(index)]\n",
@@ -1662,7 +1663,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df = df[~(df['PDSTATE'].isnull()) | (df['PDTRTMNT']!=1)]"
+    "df = df[~(df[\"PDSTATE\"].isnull()) | (df[\"PDTRTMNT\"] != 1)]"
    ]
   },
   {

--- a/livingpark_utils/scripts/pd_status.py
+++ b/livingpark_utils/scripts/pd_status.py
@@ -92,7 +92,7 @@ df.groupby(["PDSTATE", "PDTRTMNT"], dropna=False)[["REC_ID"]].count()
 
 errors = df[(df["PDSTATE"] == "ON") & (df["PDTRTMNT"] == 0)]
 # print the time difference between EXAMTM and PDMEDTM
-#(pd.to_datetime(errors["ONEXAMTM"]) - pd.to_datetime(errors["ONPDMEDTM"]))
+# (pd.to_datetime(errors["ONEXAMTM"]) - pd.to_datetime(errors["ONPDMEDTM"]))
 
 
 # <div class="alert alert-block alert-success">
@@ -233,7 +233,9 @@ HTML(pb_trunc.to_html(index=False))
 
 
 a = df.groupby(["PATNO", "EVENT_ID"]).filter(lambda x: len(x) > 2)
-index = (a[(a["PDSTATE"].isnull()) & (a["ONEXAMTM"].isnull()) & (a["OFFEXAMTM"].isnull())]).index
+index = (
+    a[(a["PDSTATE"].isnull()) & (a["ONEXAMTM"].isnull()) & (a["OFFEXAMTM"].isnull())]
+).index
 
 before_len = len(df)
 df = df[~df.index.isin(index)]
@@ -261,7 +263,7 @@ len(pb)
 
 
 before_len = len(df)
-df = df[~df.drop(["REC_ID"], axis=1).duplicated(keep='first')]
+df = df[~df.drop(["REC_ID"], axis=1).duplicated(keep="first")]
 print(f"Number of removed records: {before_len-len(df)}")
 
 
@@ -284,7 +286,7 @@ pb[["EVENT_ID", "PDSTATE", "HRPOSTMED", "OFFPDMEDDT", "OFFPDMEDTM"]]
 
 
 a = df.groupby(["PATNO", "EVENT_ID"]).filter(lambda x: len(x) > 2)
-index = (a[(a["HRPOSTMED"].isnull()) & (a["PDSTATE"] == 'OFF')]).index
+index = (a[(a["HRPOSTMED"].isnull()) & (a["PDSTATE"] == "OFF")]).index
 
 before_len = len(df)
 df = df[~df.index.isin(index)]
@@ -359,7 +361,7 @@ df.groupby(["PDSTATE", "PDTRTMNT"], dropna=False)[["REC_ID"]].count()
 # In[23]:
 
 
-df = df[~(df['PDSTATE'].isnull()) | (df['PDTRTMNT']!=1)]
+df = df[~(df["PDSTATE"].isnull()) | (df["PDTRTMNT"] != 1)]
 
 
 # Updated records distribution:


### PR DESCRIPTION
PPMI recently changed their data schema for variables related to medication:
* PDMEDDT was replaced with ONPDMEDDT and OFFPDMEDDT
* PDMEDTM was replaced with ONPDMEDTM and OFFPDMEDTM
* EXAMTM was replaced with NTEXAMTM, ONEXAMTM and OFFEXAMTM
* DBS_STATUS was replaced with DBSYN, DBSONTM and DBSOFFTM

This PR updates pd_status.ipynb to take into account these changes. 

# Inconsistencies

* There are no more records with no value for any UPDRS-III variable (removed corresponding section)
* There are no more records with PDTRTMNT=0 and PDMEDTM not empty (removed corresponding section)
* Visits with 3 exams: additional visits with 3 exams are now present in the data, which can't be solved with the previous rule only.
    * Previous rule:
        * remove exam with EXAMTM=NaN and PDSTATE=NaN when visit has 3 exams. 
    * New rules:
        * remove exam with ONEXAMTM=NaN and OFFEXAMTM=NaN and PDSTATE=NaN when visit has 3 exams (similar to previous rule). 
        * remove duplicated records.
        * remove exam with HRPOSTMED=NaN and PDSTATE=OFF when visit has 3 exams. 

# Imputation of missing values

Only 3 cases remain out of the 5 cases identified previously. Previous case 1 (PDSTATE=OFF and PDTRTMNT missing) and case 5 (PDSTATE=ON and PDTRTMNT missing) do not occur any more. The corrections for the remaining cases remain the same as before, except for previous case 3 (PDSTATE missing and PDTRTMNT=1) which now only has 2 records: for simplicity, these records are now dropped.

Note: this shouldn't be merged until Madeleine approves.