### PR TITLE
Fix download of nifti images

### DIFF
--- a/livingpark_utils/cli.py
+++ b/livingpark_utils/cli.py
@@ -46,6 +46,12 @@ def import_from(module: str, name: str) -> Any:
     default=120,
     help="Maximum duration before interrupting the download (per subject).",
 )
+@click.option(
+    "--batch-size",
+    type=int,
+    default=50,
+    help="Number of file to download in each batch."
+)
 @click.argument(
     "cohort_file", type=click.Path(exists=True, file_okay=True, readable=True)
 )
@@ -54,6 +60,7 @@ def get_T1_nifti_files(
     symlink: bool,
     force: bool,
     timeout: int,
+    batch_size: int,
     cohort_file: str,
 ):
     r"""Download T1 nifti files from cohort csv file.
@@ -72,6 +79,8 @@ def get_T1_nifti_files(
         When `True`, all study files are reported missing locally., by default False.
     timeout : int
         Number of second before the download times out., by default 120.
+    batch_size : int
+        Number of files to download in each batch.
     cohort_file : str
         Path to the csv file containing the cohort definition.
     """
@@ -86,4 +95,5 @@ def get_T1_nifti_files(
         symlink=symlink,
         force=force,
         timeout=timeout,
+        batch_size=batch_size,
     )

--- a/livingpark_utils/cli.py
+++ b/livingpark_utils/cli.py
@@ -50,7 +50,7 @@ def import_from(module: str, name: str) -> Any:
     "--batch-size",
     type=int,
     default=50,
-    help="Number of file to download in each batch."
+    help="Number of file to download in each batch.",
 )
 @click.argument(
     "cohort_file", type=click.Path(exists=True, file_okay=True, readable=True)

--- a/livingpark_utils/dataset/ppmi.py
+++ b/livingpark_utils/dataset/ppmi.py
@@ -3,6 +3,7 @@ import glob
 import logging
 import os.path
 from pprint import pprint
+import re
 
 import numpy as np
 import pandas as pd
@@ -85,15 +86,12 @@ def clean_protocol_description(desc: str) -> str:
     str
         Protocol description. Example: "MPRAGE GRAPPA"
     """
-    return (
-        desc.strip()
-        .replace(" ", "_")
-        .replace("(", "_")
-        .replace(")", "_")
-        .replace("/", "_")
-        .replace("__", "_")
-        .strip("_")
-    )
+    return re.sub(
+        r"_+",
+        "_",
+        re.sub(r"[\s()/-]", "_", desc)
+    ).strip("_")
+    
 
 
 def find_nifti_file_in_cache(

--- a/livingpark_utils/dataset/ppmi.py
+++ b/livingpark_utils/dataset/ppmi.py
@@ -2,14 +2,13 @@
 import glob
 import logging
 import os.path
-from pprint import pprint
 import re
+from pprint import pprint
 
 import numpy as np
 import pandas as pd
 from dateutil.parser import parse  # type: ignore
 from dateutil.relativedelta import relativedelta  # type: ignore
-from ppmi_downloader import fileMatchingError
 
 from ..download import ppmi
 
@@ -86,12 +85,7 @@ def clean_protocol_description(desc: str) -> str:
     str
         Protocol description. Example: "MPRAGE GRAPPA"
     """
-    return re.sub(
-        r"_+",
-        "_",
-        re.sub(r"[\s()/-]", "_", desc)
-    ).strip("_")
-    
+    return re.sub(r"_+", "_", re.sub(r"[\s()/-]", "_", desc)).strip("_")
 
 
 def find_nifti_file_in_cache(

--- a/livingpark_utils/download/ppmi.py
+++ b/livingpark_utils/download/ppmi.py
@@ -1,30 +1,49 @@
 """Downloader for the ppmi dataset."""
 import logging
 import os.path
-from pathlib import Path
 import traceback
-from urllib3.connectionpool import ReadTimeoutError
+from typing import Iterator
+from typing import Sequence
+from typing import TypeVar
 
 import pandas as pd
 import ppmi_downloader
 from ppmi_downloader import fileMatchingError
+from urllib3.connectionpool import ReadTimeoutError
 
 from .DownloaderABC import DownloaderABC
 from livingpark_utils.dataset import ppmi
 
 
 log_file = "livingpark_utils-ppmiDownloader.log"
-logging.Formatter(fmt='%(asctime)s - %(message)s', datefmt='%d-%b-%y %H:%M:%S')
+logging.Formatter(fmt="%(asctime)s - %(message)s", datefmt="%d-%b-%y %H:%M:%S")
 fh = logging.FileHandler(log_file)
 fh.setLevel(logging.ERROR)
 logger = logging.getLogger(__name__)
 logger.addHandler(fh)
 
 
-def batched(iterable, *, n):
-    l = len(iterable)
-    for ndx in range(0, l, n):
-        yield iterable[ndx : min(ndx + n, l)]
+T = TypeVar("T")
+
+
+def batched(iterable: Sequence[T], *, n: int) -> Iterator[Sequence[T]]:
+    """Segment the `iterable` into `n` batches.
+
+    Parameters
+    ----------
+    iterable : _type_
+        _description_
+    n : int
+        Number of batches.
+
+    Yields
+    ------
+    _type_
+        _description_
+    """
+    length = len(iterable)
+    for ndx in range(0, length, n):
+        yield iterable[ndx : min(ndx + n, length)]
 
 
 class Downloader(DownloaderABC):
@@ -232,7 +251,8 @@ class Downloader(DownloaderABC):
                 elif not os.path.exists(filename):
                     if debug:
                         print(
-                            f"Error: File not found, possibly due to a failed download: {filename}"
+                            "Error: File not found."
+                            f"Possibly due to a failed download: {filename}"
                         )
                 else:  # copy file to dataset
                     dest_dir = os.path.join(
@@ -253,7 +273,8 @@ class Downloader(DownloaderABC):
 
         if debug and failures > 0:
             print(
-                f"Failed to downloaded {failures} files. See {log_file} for more details"
+                f"Failed to downloaded {failures} files."
+                f"See {log_file} for more details."
             )
 
         # Update file names in cohort

--- a/livingpark_utils/download/ppmi.py
+++ b/livingpark_utils/download/ppmi.py
@@ -1,12 +1,30 @@
 """Downloader for the ppmi dataset."""
+import logging
 import os.path
+from pathlib import Path
 import traceback
+from urllib3.connectionpool import ReadTimeoutError
 
 import pandas as pd
 import ppmi_downloader
+from ppmi_downloader import fileMatchingError
 
 from .DownloaderABC import DownloaderABC
 from livingpark_utils.dataset import ppmi
+
+
+log_file = "livingpark_utils-ppmiDownloader.log"
+logging.Formatter(fmt='%(asctime)s - %(message)s', datefmt='%d-%b-%y %H:%M:%S')
+fh = logging.FileHandler(log_file)
+fh.setLevel(logging.ERROR)
+logger = logging.getLogger(__name__)
+logger.addHandler(fh)
+
+
+def batched(iterable, *, n):
+    l = len(iterable)
+    for ndx in range(0, l, n):
+        yield iterable[ndx : min(ndx + n, l)]
 
 
 class Downloader(DownloaderABC):
@@ -103,6 +121,7 @@ class Downloader(DownloaderABC):
         *,
         symlink: bool = False,
         timeout: int = 120,  # Per subject
+        batch_size: int = 50,
     ) -> tuple[pd.DataFrame, pd.DataFrame]:
         """Download the T1 NIfTI files of a dataset.
 
@@ -115,6 +134,8 @@ class Downloader(DownloaderABC):
             False
         timeout : int, optional
              Number of second before the download times out., by default 120
+        batch_size : int, optional
+            Number of subjects to download in each batch, by default 100.
 
         Returns
         -------
@@ -122,77 +143,38 @@ class Downloader(DownloaderABC):
             Tuple with the successful and missing T1 NIfTI file identifiers,
             respectively.
         """
-        cohort = query
-        missing_patno = cohort["PATNO"]
-        try:
-            ppmi_dl = ppmi_downloader.PPMIDownloader(headless=self.headless)
-            print(f"Downloading image data of {missing_patno.nunique()} subjects")
-            ppmi_dl.download_imaging_data(
-                missing_patno.unique(),
-                type="nifti",
-                timeout=timeout * missing_patno.nunique(),
-            )
-        except Exception:
-            print(traceback.format_exc())
-            missing = self.missing_T1_nifti_files(query)
-            success = query[~query["PATNO"].isin(missing["PATNO"])]
-            return success, missing
-        finally:
-            if "ppmi_dl" in locals():
-                ppmi_dl.quit()
-
-        # Find cohort file names among downloaded files
-        results_path = "outputs"
-        ppmi_fd = ppmi_downloader.PPMINiftiFileFinder()
-        for _, row in cohort.iterrows():
-            if not row["File name"] or row["File name"] is None:
-                filename = ppmi_fd.find_nifti(
-                    row["PATNO"], row["EVENT_ID"], row["Description"]
+        missing_patno = query["PATNO"]
+        print(f"Downloading image data of {missing_patno.nunique()} subjects")
+        for batch in batched(missing_patno.unique(), n=batch_size):
+            try:
+                ppmi_dl = ppmi_downloader.PPMIDownloader(headless=self.headless)
+                ppmi_dl.download_imaging_data(
+                    batch,
+                    type="nifti",
+                    timeout=timeout * len(batch),
                 )
-                if filename is None:
-                    print(
-                        "Not found: "
-                        + f"{row['PATNO'], row['EVENT_ID'], row['Description']}"
-                    )
-                else:  # copy file to dataset
-                    dest_dir = os.path.join(
-                        "inputs",
-                        f'sub-{row["PATNO"]}',
-                        f'ses-{row["EVENT_ID"]}',
-                        "anat",
-                    )
-                    os.makedirs(dest_dir, exist_ok=True)
-                    dest_file = os.path.join(dest_dir, os.path.basename(filename))
-                    os.rename(filename, dest_file)
-                    row["File name"] = dest_file
+                # We map the files in each batch to limit re-download on failures.
+                query = self._map_nifti_from_cache(query, symlink=symlink)
 
-        # Update file names in cohort
-        cohort["File name"] = cohort.apply(
-            lambda x: ppmi.find_nifti_file_in_cache(
-                x["PATNO"], x["EVENT_ID"], x["Description"]
-            ),
-            axis=1,
-        )
+            except (TimeoutError, ReadTimeoutError):
+                logger.error(traceback.format_exc())
 
-        # Create symlinks to inputs if necessary
-        if symlink:
-            for file_name in cohort["File name"].values:
-                dest_dir = os.path.dirname(file_name).replace(
-                    os.path.join(self.cache_dir, "inputs"),
-                    os.path.join(results_path, "pre_processing"),
-                )
-                dest_file = os.path.join(
-                    dest_dir,
-                    os.path.basename(file_name.replace(self.cache_dir, "")),
-                )
-                if not os.path.exists(dest_file):
-                    os.makedirs(dest_dir, exist_ok=True)
-                    os.symlink(
-                        os.path.relpath(os.path.abspath(file_name), start=dest_file),
-                        dest_file,
-                    )
+                query = self._map_nifti_from_cache(query, symlink=symlink)
+                missing = self.missing_T1_nifti_files(query)
+                success = query[~query["PATNO"].isin(missing["PATNO"])].copy()
+                return success, missing
 
-        return query, pd.DataFrame()
+            except Exception:
+                logger.error(traceback.format_exc())
+
+            finally:
+                if "ppmi_dl" in locals():
+                    ppmi_dl.quit()
+
+        query = self._map_nifti_from_cache(query, symlink=symlink, debug=True)
+        missing = self.missing_T1_nifti_files(query)
+        success = query[~query["PATNO"].isin(missing["PATNO"])].copy()
+        return success, missing
 
     def missing_T1_nifti_files(
         self, query: pd.DataFrame, *, force: bool = False
@@ -214,11 +196,93 @@ class Downloader(DownloaderABC):
         if force:
             return query
         else:
-            cohort = query
-            cohort["File name"] = cohort.apply(
+            query["File name"] = query.apply(
                 lambda x: ppmi.find_nifti_file_in_cache(
                     x["PATNO"], x["EVENT_ID"], x["Description"]
                 ),
                 axis=1,
             )
-            return cohort[cohort["File name"] == ""]
+
+            return query[query["File name"] == ""].copy()
+
+    def _map_nifti_from_cache(
+        self, cohort: pd.DataFrame, *, symlink: bool, debug: bool = False
+    ) -> pd.DataFrame:
+        # Find cohort file names among downloaded files
+        results_path = "outputs"
+        ppmi_fd = ppmi_downloader.PPMINiftiFileFinder()
+        failures = 0
+        for _, row in cohort.iterrows():
+            if not row["File name"] or row["File name"] is None:
+                try:
+                    filename = ppmi_fd.find_nifti(
+                        row["PATNO"], row["EVENT_ID"], row["Description"]
+                    )
+                except fileMatchingError:
+                    failures += 1
+                    logger.error(traceback.format_exc())
+
+                    continue
+                except Exception as e:
+                    raise e
+
+                if filename is None:
+                    continue
+
+                elif not os.path.exists(filename):
+                    if debug:
+                        print(
+                            f"Error: File not found, possibly due to a failed download: {filename}"
+                        )
+                else:  # copy file to dataset
+                    dest_dir = os.path.join(
+                        "inputs",
+                        f'sub-{row["PATNO"]}',
+                        f'ses-{row["EVENT_ID"]}',
+                        "anat",
+                    )
+                    os.makedirs(dest_dir, exist_ok=True)
+                    dest_file = os.path.join(
+                        dest_dir,
+                        os.path.basename(filename).replace(
+                            "__", "_"
+                        ),  # Edge-case for some desc.
+                    )
+                    os.rename(filename, dest_file)
+                    row["File name"] = dest_file
+
+        if debug and failures > 0:
+            print(
+                f"Failed to downloaded {failures} files. See {log_file} for more details"
+            )
+
+        # Update file names in cohort
+        cohort["File name"] = cohort.apply(
+            lambda x: ppmi.find_nifti_file_in_cache(
+                x["PATNO"], x["EVENT_ID"], x["Description"]
+            ),
+            axis=1,
+        )
+
+        # Create symlinks to inputs if necessary
+        if symlink:
+            for filename in cohort["File name"].values:
+                if filename is None or filename == "":
+                    continue
+
+                dest_dir = os.path.dirname(filename).replace(
+                    os.path.join(self.cache_dir, "inputs"),
+                    os.path.join(results_path, "pre_processing"),
+                )
+                dest_file = os.path.join(
+                    dest_dir,
+                    os.path.basename(filename.replace(self.cache_dir, "")),
+                )
+                if not os.path.exists(dest_file):
+                    os.makedirs(dest_dir, exist_ok=True)
+                    os.symlink(
+                        os.path.relpath(os.path.abspath(filename), start=dest_file),
+                        dest_file,
+                    )
+
+        return cohort

--- a/livingpark_utils/livingpark_utils.py
+++ b/livingpark_utils/livingpark_utils.py
@@ -95,6 +95,7 @@ class LivingParkUtils:
         default: DownloaderABC,
         force: bool = False,
         timeout: int = 600,
+        **kwargs,
     ) -> None:
         """Download the required study files, using a given downloader.
 
@@ -115,7 +116,7 @@ class LivingParkUtils:
             print("Download skipped: No missing files!")
         else:
             pprint(f"Downloading files: {missing}")
-            _, missing = default.get_study_files(missing, timeout=timeout)
+            _, missing = default.get_study_files(missing, timeout=timeout, **kwargs)
 
             if len(missing) > 0:
                 pprint(f"Missing files: {missing}")
@@ -131,6 +132,7 @@ class LivingParkUtils:
         force: bool = False,
         timeout: int = 120,
         fallback: DownloaderABC = None,
+        **kwargs,
     ) -> None:
         """Download the required T1 NIfTI files, using a given downloader.
 
@@ -157,12 +159,12 @@ class LivingParkUtils:
             return print("Download skipped: No missing files!")
         else:
             _, missing = default.get_T1_nifti_files(
-                missing, symlink=symlink, timeout=timeout
+                missing, symlink=symlink, timeout=timeout, **kwargs
             )
 
             if len(missing) > 0 and fallback:
                 _, missing = fallback.get_T1_nifti_files(
-                    missing, symlink=symlink, timeout=timeout
+                    missing, symlink=symlink, timeout=timeout, **kwargs
                 )
                 if len(missing) > 0:
                     with open("install_nifti.log") as fout:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [flake8]
-ignore = W5
+ignore = W5, E203
 exclude =
     .git,
     __pycache__,


### PR DESCRIPTION
Currently, some images cannot download due to mismatch in the expected filename (or path) in cache.
When a failure occurs, it stops the download for subsequent images.

This PR aims to improve the search heuristic for the file path. When an image cannot download, the script logs the error and attempt to download subsequent images.
Last, the download is now done in a user-specified batch size (50 by default). This prevents some TimeoutError from occurring.

**Note:** Depends on https://github.com/LivingPark-MRI/ppmi-scraper/pull/67.